### PR TITLE
Fix bug where E438 won't evaluate correctly

### DIFF
--- a/comparejsonld.py
+++ b/comparejsonld.py
@@ -388,10 +388,20 @@ class Utilities:
         :return: necessity
         """
         necessity: str = "absent"
-        if "expression" in shape and "expressions" in shape["expression"]:
+        list_of_expressions: list = []
+
+        if "expression" not in shape:
+            return necessity
+
+        if "expressions" in shape["expression"]:
             for expression in shape["expression"]["expressions"]:
-                if "predicate" in expression and expression["predicate"].endswith(prop):
-                    necessity = self.required_or_absent(expression)
+                list_of_expressions.append(expression)
+        else:
+            list_of_expressions.append(shape["expression"])
+
+        for expression in list_of_expressions:
+            if "predicate" in expression and expression["predicate"].endswith(prop):
+                necessity = self.required_or_absent(expression)
         return necessity
 
     @staticmethod

--- a/test_schemas.py
+++ b/test_schemas.py
@@ -339,6 +339,17 @@ class MyTestCase(unittest.TestCase):
                                 follow_redirects=True)
         self.assertIn(response.json["properties"][0]["P31"]["response"], ["not enough correct statements"])
 
+    def test_entityschema_e438(self):
+        """
+        Tests that a schemas with only 1 expression evaluates correctly
+
+        This test tests entityschema E438 (wikimedia disambiguation page) against entity Q11645745.
+        P31 should return as present
+        """
+        response = self.app.get('/api/v2?entityschema=E438&entity=Q11645745&language=en',
+                                follow_redirects=True)
+        self.assertIn(response.json["properties"][0]["P31"]["response"], ["correct", "present"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Necessity was calculated incorrectly when a shape had only 1 expression as there was no expressions key in the shape, just a single expression key.  This takes that into account.

Also added a test for this issue