### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python application
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Teester/entityshape/security/code-scanning/4](https://github.com/Teester/entityshape/security/code-scanning/4)

To fix the problem, add a `permissions` block with the minimum required privileges for this workflow, either at the workflow root (top level, after `name:` but before `jobs:`) to cover all jobs, or at the `jobs.build` section for just that job. Since there's only one job, it's simplest and most robust to add a root-level `permissions:` block, immediately after the `name:` entry (line 4). The minimal starting point CodeQL recommends is `contents: read`. However, if any of the steps (e.g., SonarCloud, Codecov) require more than read access, you may need to later expand `permissions` to include e.g. `pull-requests: write` or `issues: write`, but for the detected problem a starting point of `contents: read` suffices. No imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
